### PR TITLE
feat: add serialization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "byteorder"
@@ -222,7 +222,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
  "memoffset",
@@ -278,24 +278,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "netlink-packet-wireguard",
  "netlink-sys",
  "nix",
+ "serde",
  "thiserror",
  "x25519-dalek",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["network-programming"]
 [dependencies]
 base64 = "0.21"
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,11 +13,12 @@ use netlink_packet_wireguard::{
     constants::{WGDEVICE_F_REPLACE_PEERS, WGPEER_F_REPLACE_ALLOWEDIPS},
     nlas::{WgAllowedIpAttrs, WgDeviceAttrs, WgPeer, WgPeerAttrs},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{key::Key, net::IpAddrMask};
 
 /// WireGuard peer representation.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Peer {
     pub public_key: Key,
     pub preshared_key: Option<Key>,

--- a/src/host.rs
+++ b/src/host.rs
@@ -164,7 +164,7 @@ impl Peer {
 }
 
 /// WireGuard host representation.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Host {
     pub listen_port: u16,
     pub private_key: Option<Key>,

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,11 +7,12 @@ use std::{
 };
 
 use base64::{prelude::BASE64_STANDARD, DecodeError, Engine};
+use serde::{Deserialize, Serialize};
 
 const KEY_LENGTH: usize = 32;
 
 /// WireGuard key representation in binary form.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct Key([u8; KEY_LENGTH]);
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ mod wireguard_interface;
 #[macro_use]
 extern crate log;
 
+use serde::{Deserialize, Serialize};
 use std::process::Output;
 
 use self::{
@@ -90,7 +91,7 @@ pub use wgapi_userspace::WireguardApiUserspace;
 pub use wireguard_interface::WireguardInterfaceApi;
 
 /// Host WireGuard interface configuration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceConfiguration {
     pub name: String,
     pub prvkey: String,

--- a/src/net.rs
+++ b/src/net.rs
@@ -7,9 +7,10 @@ use netlink_packet_wireguard::{
     constants::{AF_INET, AF_INET6},
     nlas::{WgAllowedIp, WgAllowedIpAttrs},
 };
+use serde::{Deserialize, Serialize};
 
 /// IP address with CIDR.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct IpAddrMask {
     // IP v4 or v6
     pub ip: IpAddr,


### PR DESCRIPTION
Derive `Serialize` and `Deserialize` implementations for configuration structs. Meant to enable easier integration with common JSON APIs (for example an HTTP server).