### PR TITLE
fix: use CString for interface name 

### DIFF
--- a/src/bsd/ifconfig.rs
+++ b/src/bsd/ifconfig.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::CString,
     net::{Ipv4Addr, Ipv6Addr},
     os::fd::AsRawFd,
 };
@@ -46,7 +47,8 @@ impl IfReq {
             .for_each(|(i, b)| ifr_name[i] = b);
 
         // First, try to load a kernel module for this type of network interface.
-        let mod_name = format!("if_{if_name}");
+        let mod_name = CString::new(format!("if_{if_name}")).unwrap();
+
         unsafe {
             // Ignore the return value for the time being.
             kld_load(mod_name.as_ptr());


### PR DESCRIPTION
When building for freebsd code won't compile due to 
```
    Checking defguard_wireguard_rs v0.3.0 (/home/dzania/teonite/linux_route/wireguard-rs)
error[E0308]: mismatched types
    --> src/bsd/ifconfig.rs:52:22
     |
52   |             kld_load(mod_name.as_ptr());
     |             -------- ^^^^^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
     |             |
     |             arguments to this function are incorrect
     |
     = note: expected raw pointer `*const i8`
                found raw pointer `*const u8`
note: function defined here
    --> /home/dzania/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.150/src/unix/bsd/freebsdlike/freebsd/mod.rs:5539:12
     |
5539 |     pub fn kld_load(name: *const ::c_char) -> ::c_int;
```
Fix for this is using CString from `std::ffi`