### PR TITLE
fix: clear DNS configuration on Linux/freeBSD

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
 #[cfg(target_os = "linux")]
 use crate::netlink;
 use crate::{check_command_output_status, Peer, WireguardInterfaceError};
-use std::{collections::HashSet, io::Error as IoError, process::Command};
+use std::{collections::HashSet, process::Command};
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use std::{io::Write, net::IpAddr, process::Stdio};
 #[cfg(target_os = "macos")]
 use std::{
-    io::{BufRead, BufReader, Cursor},
+    io::{BufRead, BufReader, Cursor, Error as IoError},
     net::IpAddr,
 };
 
@@ -81,15 +81,13 @@ pub(crate) fn configure_dns(dns: &[IpAddr]) -> Result<(), WireguardInterfaceErro
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-pub(crate) fn clear_dns(ifname: &str) -> Result<(), IoError> {
+pub(crate) fn clear_dns(ifname: &str) -> Result<(), WireguardInterfaceError> {
     info!("Removing DNS configuration for interface {ifname}");
     let args = ["-d", ifname, "-f"];
     debug!("Executing resolvconf with args: {args:?}");
     let mut cmd = Command::new("resolvconf");
-    cmd.args(args);
-    if !cmd.status()?.success() {
-        error!("Failed to clear DNS config for interface {ifname}")
-    }
+    let output = cmd.args(args).output()?;
+    check_command_output_status(output)?;
     Ok(())
 }
 

--- a/src/wgapi_freebsd.rs
+++ b/src/wgapi_freebsd.rs
@@ -109,7 +109,10 @@ impl WireguardInterfaceApi for WireguardApiFreebsd {
     /// configurations for the specified Wireguard interface. The DNS entries are filtered
     /// for nameservers and search domains before being piped to the `resolvconf` command.
     fn configure_dns(&self, dns: &[IpAddr]) -> Result<(), WireguardInterfaceError> {
-        info!("Configuring dns for interface: {}", self.ifname);
+        info!(
+            "Configuring DNS for interface {}, using address: {dns:?}",
+            self.ifname
+        );
         configure_dns(&self.ifname, dns)?;
         Ok(())
     }

--- a/src/wgapi_freebsd.rs
+++ b/src/wgapi_freebsd.rs
@@ -103,7 +103,7 @@ impl WireguardInterfaceApi for WireguardApiFreebsd {
         Ok(host)
     }
 
-    //// Sets DNS configuration for a Wireguard interface using the `resolvconf` command.
+    /// Sets DNS configuration for a Wireguard interface using the `resolvconf` command.
     ///
     /// It executes the `resolvconf` command with appropriate arguments to update DNS
     /// configurations for the specified Wireguard interface. The DNS entries are filtered

--- a/src/wgapi_linux.rs
+++ b/src/wgapi_linux.rs
@@ -86,7 +86,7 @@ impl WireguardInterfaceApi for WireguardApiLinux {
             }
         }
         netlink::delete_interface(&self.ifname)?;
-        clear_dns(&self.ifname);
+        clear_dns(&self.ifname)?;
         Ok(())
     }
 

--- a/src/wgapi_linux.rs
+++ b/src/wgapi_linux.rs
@@ -110,7 +110,8 @@ impl WireguardInterfaceApi for WireguardApiLinux {
         let host = netlink::get_host(&self.ifname)?;
         Ok(host)
     }
-    //// Sets DNS configuration for a Wireguard interface using the `resolvconf` command.
+
+    /// Sets DNS configuration for a Wireguard interface using the `resolvconf` command.
     ///
     /// It executes the `resolvconf` command with appropriate arguments to update DNS
     /// configurations for the specified Wireguard interface. The DNS entries are filtered

--- a/src/wgapi_linux.rs
+++ b/src/wgapi_linux.rs
@@ -116,7 +116,10 @@ impl WireguardInterfaceApi for WireguardApiLinux {
     /// configurations for the specified Wireguard interface. The DNS entries are filtered
     /// for nameservers and search domains before being piped to the `resolvconf` command.
     fn configure_dns(&self, dns: &[IpAddr]) -> Result<(), WireguardInterfaceError> {
-        info!("Configuring dns for interface: {}", self.ifname);
+        info!(
+            "Configuring DNS for interface {}, using address: {dns:?}",
+            self.ifname
+        );
         configure_dns(&self.ifname, dns)?;
         Ok(())
     }

--- a/src/wgapi_userspace.rs
+++ b/src/wgapi_userspace.rs
@@ -126,7 +126,10 @@ impl WireguardInterfaceApi for WireguardApiUserspace {
     /// - Linux
     /// - FreeBSD
     fn configure_dns(&self, dns: &[IpAddr]) -> Result<(), WireguardInterfaceError> {
-        info!("Configuring dns for interface: {}", self.ifname);
+        info!(
+            "Configuring DNS for interface {}, using address: {dns:?}",
+            self.ifname
+        );
         // Setting DNS is not supported for macOS.
         #[cfg(target_os = "macos")]
         {

--- a/src/wgapi_userspace.rs
+++ b/src/wgapi_userspace.rs
@@ -229,7 +229,7 @@ impl WireguardInterfaceApi for WireguardApiUserspace {
         }
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
-            clear_dns(&self.ifname);
+            clear_dns(&self.ifname)?;
         }
 
         Ok(())

--- a/src/wgapi_userspace.rs
+++ b/src/wgapi_userspace.rs
@@ -110,6 +110,7 @@ impl WireguardInterfaceApi for WireguardApiUserspace {
         check_command_output_status(output)?;
         Ok(())
     }
+
     /// Sets DNS configuration for a WireGuard interface using the `resolvconf` command.
     ///
     /// This function is platform-specific and is intended for use on Linux and FreeBSD.


### PR DESCRIPTION
Actually call the command used to clear DNS configuration and check the output status.