### PR TITLE
fix: hide private keys in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "defguard_wireguard_rs"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "log"
@@ -311,9 +311,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -322,18 +322,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defguard_wireguard_rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A unified multi-platform high-level API for managing WireGuard interfaces"
 license = "Apache-2.0"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -40,13 +40,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         port: 12345,
         peers: vec![peer],
     };
+    println!("Prepared interface configuration: {interface_config:?}");
 
     // apply initial interface configuration
     wgapi.configure_interface(&interface_config)?;
 
     // read current interface status
     let host = wgapi.read_interface_data()?;
-    println!("WireGuard interface initial config: {host:#?}");
+    println!("WireGuard interface after configuration: {host:#?}");
 
     // add more WireGuard clients
     for peer_id in 3..13 {

--- a/src/host.rs
+++ b/src/host.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    fmt::{Debug, Formatter},
     io::{self, BufRead, BufReader, Read},
     net::SocketAddr,
     str::FromStr,
@@ -164,12 +165,23 @@ impl Peer {
 }
 
 /// WireGuard host representation.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Host {
     pub listen_port: u16,
     pub private_key: Option<Key>,
     pub(super) fwmark: Option<u32>,
     pub peers: HashMap<Key, Peer>,
+}
+
+// implement manually to avoid exposing private keys
+impl Debug for Host {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Host")
+            .field("listen_port", &self.listen_port)
+            .field("fwmark", &self.fwmark)
+            .field("peers", &self.peers)
+            .finish()
+    }
 }
 
 impl Host {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ mod wireguard_interface;
 extern crate log;
 
 use serde::{Deserialize, Serialize};
-use std::process::Output;
+use std::{
+    fmt::{Debug, Formatter},
+    process::Output,
+};
 
 use self::{
     error::WireguardInterfaceError,
@@ -92,13 +95,25 @@ pub use wgapi_userspace::WireguardApiUserspace;
 pub use wireguard_interface::WireguardInterfaceApi;
 
 /// Host WireGuard interface configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct InterfaceConfiguration {
     pub name: String,
     pub prvkey: String,
     pub address: String,
     pub port: u32,
     pub peers: Vec<Peer>,
+}
+
+// implement manually to avoid exposing private keys
+impl Debug for InterfaceConfiguration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InterfaceConfiguration")
+            .field("name", &self.name)
+            .field("address", &self.address)
+            .field("port", &self.port)
+            .field("peers", &self.peers)
+            .finish()
+    }
 }
 
 impl TryFrom<&InterfaceConfiguration> for Host {


### PR DESCRIPTION
Add manual `Debug` implementations to hide private keys in logs.