### PR TITLE
fix: serializing and deserializing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "netlink-sys",
  "nix",
  "serde",
+ "serde_json",
  "thiserror",
  "x25519-dalek",
 ]
@@ -220,6 +221,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
@@ -408,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +444,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0"
 [dev-dependencies]
 env_logger = "0.11"
 x25519-dalek = { version = "2.0", features = ["getrandom", "static_secrets"] }
+serde_json = "1.0"
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/src/key.rs
+++ b/src/key.rs
@@ -23,7 +23,7 @@ fn hex_value(char: u8) -> Option<u8> {
 
 /// WireGuard key representation in binary form.
 #[derive(Clone, Default, Serialize, Deserialize)]
-#[serde(try_from = "&str")]
+#[serde(into = "String", try_from = "&str")]
 pub struct Key([u8; KEY_LENGTH]);
 
 impl Key {
@@ -166,6 +166,12 @@ impl fmt::Display for Key {
     }
 }
 
+impl Into<String> for Key {
+    fn into(self) -> String {
+        self.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,5 +212,15 @@ mod tests {
             "000102030405060708090a0b0c0d0e0ff0e1d2c3b4a5968778695a4b3c2d1e0f"
         );
         assert_eq!(format!("{key}"), key_str);
+    }
+
+    #[test]
+    fn serde() {
+        let key_str = "AAECAwQFBgcICQoLDA0OD/Dh0sO0pZaHeGlaSzwtHg8=";
+        let key: Key = key_str.try_into().unwrap();
+        let json = serde_json::to_string(&key).unwrap();
+        assert_eq!(json, "\"AAECAwQFBgcICQoLDA0OD/Dh0sO0pZaHeGlaSzwtHg8=\"");
+        let deserialized_key = serde_json::from_str(&json).unwrap();
+        assert_eq!(key, deserialized_key);
     }
 }


### PR DESCRIPTION
## Problem

Serializing a key will create produce a byte array. However, a string is expected when deserializing because of the `try_from` container attribute. This will cause the deserialization to never succeed.

Error message: `invalid type: sequence, expected a borrowed string`

Actual serialized data: `public_key = [235, 184, 242, 187, 12, 37, 226, 203, 78, 98, 101, 18, 30, 55, 163, 254, 57, 26, 130, 22, 203, 42, 222, 28, 77, 164, 163, 52, 55, 176, 144, 120]` (toml)

## Solution

I fixed this by adding another attribute `into="String"` to the container. Unfortunately, setting `into="&str"` won't work because it is not owned.

I also added a simple unit test to prevent regressions.