### PR TITLE
disable auto startup for Windows tunnel service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .idea/
 .vscode/
+.direnv
+.envrc

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use defguard_wireguard_rs::{
-    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, Kernel, Userspace, WGApi,
+    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, Kernel, WGApi,
     WireguardInterfaceApi,
 };
 use x25519_dalek::{EphemeralSecret, PublicKey};

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use defguard_wireguard_rs::{
-    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, Kernel, Userspace, WGApi,
+    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, Kernel, WGApi,
     WireguardInterfaceApi,
 };
 use x25519_dalek::{EphemeralSecret, PublicKey};

--- a/examples/userspace.rs
+++ b/examples/userspace.rs
@@ -1,14 +1,10 @@
-use std::{
-    io::{stdin, stdout, Read, Write},
-    net::SocketAddr,
-    str::FromStr,
-};
+#[cfg(target_os = "macos")]
+use std::io::{stdin, stdout, Read, Write};
 
-use defguard_wireguard_rs::{host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration};
 #[cfg(target_os = "macos")]
 use defguard_wireguard_rs::{Userspace, WGApi, WireguardInterfaceApi};
-use x25519_dalek::{EphemeralSecret, PublicKey};
 
+#[cfg(target_os = "macos")]
 fn pause() {
     let mut stdout = stdout();
     stdout.write_all(b"Press Enter to continue...").unwrap();

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744943606,
+        "narHash": "sha256-VL4swGy4uBcHvX+UR5pMeNE9uQzXfA7B37lkwet1EmA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ec22cd63500f4832d1f3432d2425e0b31b0361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Rust development flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      overlays = [(import rust-overlay)];
+      pkgs = import nixpkgs {
+        inherit system overlays;
+      };
+      rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        extensions = ["rust-analyzer" "rust-src" "rustfmt" "clippy"];
+      };
+      # define shared build inputs
+      nativeBuildInputs = with pkgs; [rustToolchain pkg-config];
+    in {
+      devShells.default = pkgs.mkShell {
+        inherit nativeBuildInputs;
+
+        # Specify the rust-src path (many editors rely on this)
+        RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+      };
+    });
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,11 +34,8 @@ pub enum WireguardInterfaceError {
     #[error("DNS error: {0}")]
     DnsError(String),
     #[cfg(target_os = "windows")]
-    #[error("Service installation failed: `{message}`")]
-    ServiceInstallationFailed {
-        err: std::io::Error,
-        message: String,
-    },
+    #[error("Service installation failed: `{0}`")]
+    ServiceInstallationFailed(String),
     #[cfg(target_os = "windows")]
     #[error("Tunnel service removal failed: `{0}`")]
     ServiceRemovalFailed(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,11 +33,15 @@ pub enum WireguardInterfaceError {
     KernelNotSupported,
     #[error("DNS error: {0}")]
     DnsError(String),
+    #[cfg(target_os = "windows")]
     #[error("Service installation failed: `{message}`")]
     ServiceInstallationFailed {
         err: std::io::Error,
         message: String,
     },
+    #[cfg(target_os = "windows")]
+    #[error("Tunnel service removal failed: `{0}`")]
+    ServiceRemovalFailed(String),
     #[error("Socket is closed: {0}")]
     SocketClosed(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@ mod wireguard_interface;
 #[macro_use]
 extern crate log;
 
-use std::{fmt, process::Output};
+use std::fmt;
+#[cfg(not(target_os = "windows"))]
+use std::process::Output;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ impl TryFrom<&InterfaceConfiguration> for Host {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 /// Utility function which checks external command output status.
 fn check_command_output_status(output: Output) -> Result<(), WireguardInterfaceError> {
     if !output.status.success() {

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -467,6 +467,7 @@ fn get_interface_index(ifname: &str) -> NetlinkResult<Option<u32>> {
     Ok(None)
 }
 
+#[cfg(test)]
 /// Get default route for a given address family.
 pub(crate) fn get_gateway(address_family: AddressFamily) -> NetlinkResult<Option<IpAddr>> {
     let header = RouteHeader {
@@ -493,16 +494,13 @@ pub(crate) fn get_gateway(address_family: AddressFamily) -> NetlinkResult<Option
             // Because messages can't be properly filtered, find the first `Gateway`.
             if let RouteNetlinkMessage::NewRoute(RouteMessage { attributes, .. }) = message {
                 for nla in attributes {
-                    match nla {
-                        RouteAttribute::Gateway(address) => {
-                            debug!("Found gateway {address:?}");
-                            match address {
-                                RouteAddress::Inet(ipv4) => return Ok(Some(IpAddr::V4(ipv4))),
-                                RouteAddress::Inet6(ipv6) => return Ok(Some(IpAddr::V6(ipv6))),
-                                _ => (),
-                            }
+                    if let RouteAttribute::Gateway(address) = nla {
+                        debug!("Found gateway {address:?}");
+                        match address {
+                            RouteAddress::Inet(ipv4) => return Ok(Some(IpAddr::V4(ipv4))),
+                            RouteAddress::Inet6(ipv6) => return Ok(Some(IpAddr::V6(ipv6))),
+                            _ => (),
                         }
-                        _ => (),
                     }
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,17 +2,19 @@
 use std::io::{BufRead, BufReader, Cursor, Error as IoError};
 #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "netbsd"))]
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{SocketAddr, ToSocketAddrs};
 #[cfg(target_os = "linux")]
 use std::{collections::HashSet, fs::OpenOptions};
 #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "netbsd"))]
 use std::{io::Write, process::Stdio};
-use std::{
-    net::{IpAddr, SocketAddr, ToSocketAddrs},
-    process::Command,
-};
+#[cfg(not(target_os = "windows"))]
+use std::{net::IpAddr, process::Command};
 
 #[cfg(target_os = "freebsd")]
 use crate::check_command_output_status;
+#[cfg(not(target_os = "windows"))]
+use crate::Peer;
+use crate::WireguardInterfaceError;
 #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "netbsd"))]
 use crate::{
     bsd::{add_gateway, add_linked_route, get_gateway},
@@ -21,7 +23,6 @@ use crate::{
 };
 #[cfg(target_os = "linux")]
 use crate::{check_command_output_status, netlink, IpVersion};
-use crate::{Peer, WireguardInterfaceError};
 
 #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn configure_dns(

--- a/src/wgapi_linux.rs
+++ b/src/wgapi_linux.rs
@@ -53,7 +53,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
         // Assign IP addresses to the interface.
         for address in &config.addresses {
             debug!("Assigning address {address} to interface {}", self.ifname);
-            self.assign_address(&address)?;
+            self.assign_address(address)?;
             debug!(
                 "Address {address} assigned to interface {} successfully",
                 self.ifname
@@ -102,9 +102,9 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
     /// If allowed IPs contain a default route, instead of adding a route for every peer, the following changes are made:
     /// - A new default route is added
     /// - The current default route is suppressed by modifying the main routing table rule with `suppress_prefixlen 0`, this makes
-    ///     it so that the whole main routing table rules are still applied except for the default route rules (so the new default route is used instead)
+    ///   it so that the whole main routing table rules are still applied except for the default route rules (so the new default route is used instead)
     /// - A rule pushing all traffic through the WireGuard interface is added with the exception of traffic marked with 51820 (default) fwmark which
-    ///    is used for the WireGuard traffic itself (so it doesn't get stuck in a loop)
+    ///   is used for the WireGuard traffic itself (so it doesn't get stuck in a loop)
     ///
     fn configure_peer_routing(&self, peers: &[Peer]) -> Result<(), WireguardInterfaceError> {
         add_peer_routing(peers, &self.ifname)?;

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -219,6 +219,18 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                 WireguardInterfaceError::ServiceInstallationFailed { err, message }
             })?;
 
+        debug!("Done disabling automatic restart for the new service. Service update output: {service_update_output:?}",);
+        if !service_update_output.status.success() {
+            let message = format!(
+                "Failed to configure WireGuard tunnel service: {:?}",
+                service_update_output.stdout
+            );
+            return Err(WireguardInterfaceError::ServiceInstallationFailed {
+                err: io::Error::new(io::ErrorKind::Other, "Cannot configure service"),
+                message,
+            });
+        }
+
         // TODO: set maximum transfer unit (MTU)
 
         info!(

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -257,7 +257,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                 "Failed to remove WireGuard tunnel service: {:?}",
                 command_output.stdout
             );
-            return Err(WireguardInterfaceError::ServiceRemovalFailed { message });
+            return Err(WireguardInterfaceError::ServiceRemovalFailed(message));
         }
 
         info!("Interface {} removed successfully", self.ifname);

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -257,7 +257,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                 "Failed to remove WireGuard tunnel service: {:?}",
                 command_output.stdout
             );
-            return Err(WireguardInterfaceError::ServiceRemovalError { message });
+            return Err(WireguardInterfaceError::ServiceRemovalFailed { message });
         }
 
         info!("Interface {} removed successfully", self.ifname);

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -187,8 +187,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
             .output()
             .map_err(|err| {
                 error!("Failed to create interface. Error: {err}");
-                let message = err.to_string();
-                WireguardInterfaceError::ServiceInstallationFailed { err, message }
+                WireguardInterfaceError::ServiceInstallationFailed(err.to_string())
             })?;
 
         debug!("Done installing the new service. Service installation output: {service_installation_output:?}",);
@@ -198,10 +197,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                 "Failed to install WireGuard tunnel as a Windows service: {:?}",
                 service_installation_output.stdout
             );
-            return Err(WireguardInterfaceError::ServiceInstallationFailed {
-                err: io::Error::new(io::ErrorKind::Other, "Cannot create service"),
-                message,
-            });
+            return Err(WireguardInterfaceError::ServiceInstallationFailed(message));
         }
 
         debug!(
@@ -215,8 +211,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
             .output()
             .map_err(|err| {
                 error!("Failed to configure tunnel service. Error: {err}");
-                let message = err.to_string();
-                WireguardInterfaceError::ServiceInstallationFailed { err, message }
+                WireguardInterfaceError::ServiceInstallationFailed(err.to_string())
             })?;
 
         debug!("Done disabling automatic restart for the new service. Service update output: {service_update_output:?}",);
@@ -225,10 +220,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                 "Failed to configure WireGuard tunnel service: {:?}",
                 service_update_output.stdout
             );
-            return Err(WireguardInterfaceError::ServiceInstallationFailed {
-                err: io::Error::new(io::ErrorKind::Other, "Cannot configure service"),
-                message,
-            });
+            return Err(WireguardInterfaceError::ServiceInstallationFailed(message));
         }
 
         // TODO: set maximum transfer unit (MTU)

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     fs::File,
-    io::{self, BufRead, BufReader, Cursor, Write},
+    io::{BufRead, BufReader, Cursor, Write},
     net::{IpAddr, SocketAddr},
     process::Command,
     str::FromStr,
@@ -94,9 +94,8 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
         }
 
         for peer in &config.peers {
-            wireguard_configuration.push_str(
-                format!("\n[Peer]\nPublicKey = {}", peer.public_key.to_string()).as_str(),
-            );
+            wireguard_configuration
+                .push_str(format!("\n[Peer]\nPublicKey = {}", peer.public_key).as_str());
 
             if let Some(preshared_key) = &peer.preshared_key {
                 wireguard_configuration
@@ -175,7 +174,7 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
                     break;
                 }
 
-                counter = counter + 1;
+                counter += 1;
             }
             debug!("Finished waiting for service to be removed, the service is considered to be removed, proceeding further");
         }

--- a/src/wgapi_windows.rs
+++ b/src/wgapi_windows.rs
@@ -204,6 +204,21 @@ impl WireguardInterfaceApi for WGApi<Kernel> {
             });
         }
 
+        debug!(
+            "Disabling automatic restart for interface {} tunnel service",
+            self.ifname
+        );
+        let service_update_output = Command::new("sc")
+            .arg("config")
+            .arg(format!("WireGuardTunnel${}", self.ifname))
+            .arg("start=demand")
+            .output()
+            .map_err(|err| {
+                error!("Failed to configure tunnel service. Error: {err}");
+                let message = err.to_string();
+                WireguardInterfaceError::ServiceInstallationFailed { err, message }
+            })?;
+
         // TODO: set maximum transfer unit (MTU)
 
         info!(


### PR DESCRIPTION
This changes default tunnel service behavior under Windows by disabling automatic restart.
This resolves the issue we've had with tunnels persisting through reboots unless the client has been manually closed.